### PR TITLE
add configuration option to disable influx health check

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,7 @@
   "influx_password": "",
   "influx_token": "",
   "influx_org": "",
+  "influx_health_check_disabled": false,
   "always_write_weather_as_current": false,
   "write_heat_pump_1": false,
   "write_heat_pump_2": false,


### PR DESCRIPTION
This addresses #10. While I'm not the biggest fan of negative configuration names this way the default is false i.e. InfluxDB health checks are enabled; this also makes it in line with the rest of the boolean config options.

Here are the testing results:

```
$ grep influx_health config.json
$ grep influx_health config-no-health.json
  "influx_health_check_disabled": true,
$ ecobee-influx-connector -config=config.json
2022/02/22 17:16:17 failed to check InfluxDB health: Unexpected status code 404
$ ecobee-influx-connector -config=config-no-health.json
2022/02/22 17:16:26 latest runtime interval available is 276
Thermostat conditions at 2022-02-22 22:55:00 +0000 UTC:
```