### PR TITLE
Improve lint, build, CI, and release process

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -1,0 +1,6 @@
+-s dir
+--name ecobee_influx_connector
+--description "Ship your Ecobee runtime, sensor and weather data to InfluxDB."
+--url "https://github.com/cdzombak/ecobee_influx_connector"
+--maintainer "Chris Dzombak <https://www.dzombak.com>"
+--license Apache-2.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+---
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check if this is a running version tag update
         id: running_version_tag
         run: |
-          if [[ "${{ github.event_name }}" = "pull_request" ]]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
               echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"
           elif [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
               echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
 
 
   docker:
-    name: Build & Push Docker Images
+    name: Docker Images
     needs: [lint, meta]
     if: needs.meta.outputs.is_running_version_tag_update != 'true'
     runs-on: ubuntu-latest
@@ -178,7 +178,7 @@ jobs:
 
 
   binaries:
-    name: Build Binaries & Debian Packages
+    name: Binaries & Debian Packages
     needs: [lint, meta]
     if: needs.meta.outputs.is_running_version_tag_update != 'true'
     runs-on: ubuntu-latest
@@ -266,7 +266,7 @@ jobs:
 
 
   packagecloud:
-    name: Push to PackageCloud
+    name: PackageCloud
     needs: [meta, binaries]
     if: needs.meta.outputs.is_release == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Check if this is a running version tag update
         id: running_version_tag
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${{ github.event_name }}" = "pull_request" ]]; then
+              echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"
+          elif [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
               echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
           elif [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+$ ]]; then
               echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,74 +1,297 @@
-# This is a basic workflow to help you get started with Actions
-
+---
 name: CI
 
-# Controls when the action will run. 
-on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+"on":
   push:
-    branches: [ main ]
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
   pull_request:
-    branches: [ main ]
+    branches:
+      - "main"
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+permissions:
+  contents: read
+
+env:
+  DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6"
+  FPM_VERSION: 1.15.1
 
 jobs:
-  docker:
+
+  meta:
+    name: Derive Build Metadata
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Prepare
-        id: prep
+        uses: actions/checkout@v4
+      - name: Derive version string
+        id: bin_version
+        run: echo "bin_version=$(./.version.sh)" >> "$GITHUB_OUTPUT"
+      - name: bin_version
+        run: 'echo bin_version: ${{ steps.bin_version.outputs.bin_version }}'
+      - name: Check if this is a running version tag update
+        id: running_version_tag
         run: |
-          DOCKER_IMAGE=${{ secrets.DOCKER_USERNAME }}/${GITHUB_REPOSITORY#*/}
-          VERSION=latest
-          SHORTREF=${GITHUB_SHA::8}
-
-          # If this is git tag, use the tag name as a docker tag
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
+              echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
+          elif [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+$ ]]; then
+              echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
+      - name: is_running_version_tag
+        run: 'echo is_running_version_tag_update: ${{ steps.running_version_tag.outputs.is_running_version_tag_update }}'
+    outputs:
+      bin_name: ${{ github.event.repository.name }}
+      bin_version: ${{ steps.bin_version.outputs.bin_version }}
+      dockerhub_owner: ${{ github.repository_owner }}
+      ghcr_owner: ${{ github.repository_owner }}
+      packagecloud_owner: ${{ github.repository_owner }}
+      packagecloud_repo: oss
+      is_prerelease: >-
+            ${{
+              steps.running_version_tag.outputs.is_running_version_tag_update != 'true' &&
+              startsWith(github.ref, 'refs/tags/v') &&
+                (contains(github.ref, '-alpha.')
+                || contains(github.ref, '-beta.')
+                || contains(github.ref, '-rc.'))
+            }}
+      is_release: >-
+            ${{
+              steps.running_version_tag.outputs.is_running_version_tag_update != 'true' &&
+              startsWith(github.ref, 'refs/tags/v') &&
+                !(contains(github.ref, '-alpha.')
+                || contains(github.ref, '-beta.')
+                || contains(github.ref, '-rc.'))
+            }}
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
+      is_running_version_tag_update: ${{ steps.running_version_tag.outputs.is_running_version_tag_update }}
 
-          # If the VERSION looks like a version number, assume that
-          # this is the most recent version of the image and also
-          # tag it 'latest'.
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
-          fi
 
-          # Set output parameters.
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run MegaLinter
+        uses: oxsecurity/megalinter@v7
+        env:
+          # See https://megalinter.io/configuration and .mega-linter.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive MegaLinter artifacts
+        if: ( !env.ACT && ( success() || failure() ) )
+        uses: actions/upload-artifact@v3
+        with:
+          name: MegaLinter artifacts
+          path: |
+            megalinter-reports
+            mega-linter.log
+
+
+  docker:
+    name: Build & Push Docker Images
+    needs: [lint, meta]
+    if: needs.meta.outputs.is_running_version_tag_update != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        if: needs.meta.outputs.is_pull_request != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: needs.meta.outputs.is_pull_request != 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
 
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          images: |
+            ${{ needs.meta.outputs.dockerhub_owner }}/${{ needs.meta.outputs.bin_name }}
+            ghcr.io/${{ needs.meta.outputs.ghcr_owner }}/${{ needs.meta.outputs.bin_name }}
+          tags: |
+            type=raw,value=latest,enable=${{ needs.meta.outputs.is_release == 'true' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
-      - name: Build
-        uses: docker/build-push-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
-          push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          builder: ${{ steps.buildx.outputs.name }}
+          push: ${{ needs.meta.outputs.is_pull_request != 'true' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: |
+            BIN_VERSION=${{ needs.meta.outputs.bin_version }}
+
+      - name: Update Docker Hub description
+        if: needs.meta.outputs.is_release == 'true'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ needs.meta.outputs.dockerhub_owner }}/${{ needs.meta.outputs.bin_name }}
+          readme-filepath: ./README.md
+          short-description: ${{ github.event.repository.description }}
+
+
+  binaries:
+    name: Build Binaries & Debian Packages
+    needs: [lint, meta]
+    if: needs.meta.outputs.is_running_version_tag_update != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      - name: Go version
+        run: go version
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Ruby version
+        run: ruby --version
+      - name: Install fpm
+        run: |
+          gem install --no-document fpm -v "$FPM_VERSION"
+
+      - name: Build binaries & packages
+        run: make package
+      - name: Prepare release artifacts
+        working-directory: out/
+        run: |
+          mkdir ./gh-release
+          cp ./*.deb ./gh-release/
+          find . -name '${{ needs.meta.outputs.bin_name }}-*' -executable -type f -maxdepth 1 -print0 | xargs -0 -I {} tar --transform='flags=r;s|.*|${{ needs.meta.outputs.bin_name }}|' -czvf ./gh-release/{}.tar.gz {}
+      - name: Upload binaries & packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
+          path: out/gh-release/*
+
+
+  release:
+    name: GitHub (Pre)Release
+    needs: [meta, binaries]
+    if: >-
+          needs.meta.outputs.is_release == 'true' ||
+          needs.meta.outputs.is_prerelease == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download binaries & packages
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
+          path: out
+      - name: List artifacts
+        working-directory: out
+        run: ls -R
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: out/${{ needs.meta.outputs.bin_name }}-*
+          prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+
+  tags:
+    name: Update Release Tags
+    needs: [meta, release]
+    if: needs.meta.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update running major/minor version tags
+        uses: sersoft-gmbh/running-release-tags-action@v3
+        with:
+          fail-on-non-semver-tag: true
+          create-release: false
+          update-full-release: false
+
+
+  packagecloud:
+    name: Push to PackageCloud
+    needs: [meta, binaries]
+    if: needs.meta.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download binaries & packages
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
+          path: out
+      - name: List artifacts
+        run: ls -R
+        working-directory: out
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Ruby version
+        run: ruby --version
+      - name: Install PackageCloud CLI
+        run: |
+          gem install --no-document package_cloud
+
+      - name: Push to PackageCloud
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+        run: |
+          package_cloud push --yes ${{ needs.meta.outputs.packagecloud_owner }}/${{ needs.meta.outputs.packagecloud_repo }}/any/any out/*.deb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Check if this is a running version tag update
         id: running_version_tag
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ -z "${{ github.event.ref }}" ]; then
               echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"
-          elif [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
+          elif [[ "${{ github.event.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
               echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
-          elif [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+$ ]]; then
+          elif [[ "${{ github.event.ref }}" =~ ^refs/tags/v[0-9]+$ ]]; then
               echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
           else
               echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,24 @@
+# https://megalinter.io/configuration/
+
+---
+APPLY_FIXES: all
+DISABLE:
+  - COPYPASTE
+  - DOCKERFILE
+  - REPOSITORY
+  - SPELL
+DISABLE_LINTERS:
+  - GO_GOLANGCI_LINT
+  - MAKEFILE_CHECKMAKE
+PLUGINS:
+  - https://raw.githubusercontent.com/shiranr/linkcheck/main/mega-linter-plugin-linkcheck/linkcheck.megalinter-descriptor.yml
+  - https://raw.githubusercontent.com/cdzombak/mega-linter-plugin-dockerfilelint/main/mega-linter-plugin-dockerfilelint/dockerfilelint.megalinter-descriptor.yml
+
+GO_REVIVE_CONFIG_FILE: ".revive.toml"
+GO_REVIVE_FILTER_REGEX_EXCLUDE: "(ecobee/)"
+MARKDOWN_MARKDOWNLINT_ARGUMENTS: "--disable MD013"
+
+VALIDATE_ALL_CODEBASE: true
+SHOW_ELAPSED_TIME: false
+FILEIO_REPORTER: false
+PRINT_ALPACA: false

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,31 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+	Disabled = true
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/.version.sh
+++ b/.version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "$(git tag --points-at HEAD)" ]; then
+	git describe --always --long --dirty | sed 's/^v//'
+else
+	git tag --points-at HEAD | sed 's/^v//' | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | tail -n 1
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ FROM golang:1-alpine AS builder
 ARG BIN_NAME
 ARG BIN_VERSION
 WORKDIR /src/ecobee_influx_connector
+RUN apk add --no-cache ca-certificates
 COPY . .
 RUN go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
 FROM scratch
 ARG BIN_NAME
 COPY --from=builder /src/ecobee_influx_connector/out/${BIN_NAME} /usr/bin/ecobee_influx_connector
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 VOLUME /config
 ENTRYPOINT ["/usr/bin/ecobee_influx_connector"]
 CMD ["-config", "/config/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME /config
 ENTRYPOINT ["/usr/bin/ecobee_influx_connector"]
 CMD ["-config", "/config/config.json"]
 
-LABEL license="LGPL3"
+LABEL license="Apache-2.0"
 LABEL maintainer="Chris Dzombak <https://www.dzombak.com>"
 LABEL org.opencontainers.image.authors="Chris Dzombak <https://www.dzombak.com>"
 LABEL org.opencontainers.image.url="https://github.com/cdzombak/ecobee_influx_connector"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BIN_NAME=ecobee_influx_connector
 ARG BIN_VERSION=<unknown>
 
-FROM golang:1 AS builder
+FROM golang:1-alpine AS builder
 ARG BIN_NAME
 ARG BIN_VERSION
 WORKDIR /src/ecobee_influx_connector

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,27 @@
-FROM golang:1
+ARG BIN_NAME=ecobee_influx_connector
+ARG BIN_VERSION=<unknown>
 
-WORKDIR /go/src/app
+FROM golang:1 AS builder
+ARG BIN_NAME
+ARG BIN_VERSION
+WORKDIR /src/ecobee_influx_connector
 COPY . .
+RUN go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
-RUN go get -d -v ./...
-RUN go install -v ./...
-RUN go build -o ./ecobee_influx_connector .
-
-CMD /go/src/app/ecobee_influx_connector -config "/config/config.json"
-
+FROM scratch
+ARG BIN_NAME
+COPY --from=builder /src/ecobee_influx_connector/out/${BIN_NAME} /usr/bin/ecobee_influx_connector
 VOLUME /config
+ENTRYPOINT ["/usr/bin/ecobee_influx_connector"]
+CMD ["-config", "/config/config.json"]
+
+LABEL license="LGPL3"
+LABEL maintainer="Chris Dzombak <https://www.dzombak.com>"
+LABEL org.opencontainers.image.authors="Chris Dzombak <https://www.dzombak.com>"
+LABEL org.opencontainers.image.url="https://github.com/cdzombak/ecobee_influx_connector"
+LABEL org.opencontainers.image.documentation="https://github.com/cdzombak/ecobee_influx_connector/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/cdzombak/ecobee_influx_connector.git"
+LABEL org.opencontainers.image.version="${BIN_VERSION}"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.title="${BIN_NAME}"
+LABEL org.opencontainers.image.description="Ship your Ecobee runtime, sensor and weather data to InfluxDB."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+SHELL:=/usr/bin/env bash
+
+BIN_NAME:=ecobee_influx_connector
+BIN_VERSION:=$(shell ./.version.sh)
+
+default: help
+.PHONY: help  # via https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: all
+all: clean build-linux-amd64 build-linux-arm64 build-linux-armv7 build-linux-armv6 ## Build for Linux (amd64, arm64, armv7, armv6)
+
+.PHONY: clean
+clean: ## Remove build products (./out)
+	rm -rf ./out
+
+.PHONY: build
+build: ## Build for the current platform & architecture to ./out
+	mkdir -p out
+	go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
+
+.PHONY: build-linux-amd64
+build-linux-amd64: ## Build for Linux/amd64 to ./out
+	env GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64 .
+
+.PHONY: build-linux-arm64
+build-linux-arm64: ## Build for Linux/arm64 to ./out
+	env GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64 .
+
+.PHONY: build-linux-armv7
+build-linux-armv7: ## Build for Linux/armv7 to ./out
+	env GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv7 .
+
+.PHONY: build-linux-armv6
+build-linux-armv6: ## Build for Linux/armv6 to ./out
+	env GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6 .
+
+.PHONY: package
+package: all ## Build all binaries + .deb packages to ./out (requires fpm: https://fpm.readthedocs.io)
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-amd64.deb -a amd64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-arm64.deb -a arm64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-armhf.deb -a armhf ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv7=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-armel.deb -a armel ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6=/usr/bin/${BIN_NAME}
+
+.PHONY: lint
+lint: ## Lint all source files in this repository (requires nektos/act: https://nektosact.com)
+	act --artifact-server-path /tmp/artifacts -j lint
+
+.PHONY: update-lint
+update-lint: ## Pull updated images supporting the lint target (may fetch >10 GB!)
+	docker pull catthehacker/ubuntu:full-latest
+
+GOLINT_FILES:=$(shell find . -name '*.go' | grep -v /vendor/)
+.PHONY: golint
+golint: ## Lint all .go files with golint
+	@for file in ${GOLINT_FILES} ;  do \
+		echo "$$file" ; \
+		golint $$file ; \
+	done

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ecobee -> InfluxDB Connector
 
+Ship your Ecobee runtime, sensor and weather data to InfluxDB.
+
 ## Getting Started
 
 1. Register and enable the developer dashboard on your Ecobee account at https://www.ecobee.com/developers/
@@ -33,7 +35,7 @@ To use the Docker container make sure the path to the `config.json` is provided 
 
 ### Important
 
-Before building a persistent container, you will want to execute `docker run --rm -it -v $HOME/ecobee:/config cdzombak/ecobee_influx_connector /go/src/app/ecobee_influx_connector -config "/config/config.json" -list-thermostats` so that you can get your token cached (`/config/ecobee-cred-cache`). This will give you a single key you can then use to authenticate with your ecobee api app. After auth you should see the thermostat_ids listed for all your devices.
+Before building a persistent container, you will want to execute `docker run --rm -it -v $HOME/ecobee:/config cdzombak/ecobee_influx_connector -config "/config/config.json" -list-thermostats` so that you can get your token cached (`/config/ecobee-cred-cache`). This will give you a single key you can then use to authenticate with your ecobee api app. After auth you should see the thermostat_ids listed for all your devices.
 
 If you build a persistent container before performing the above, the initial token request will loop and it will be hard to get the cached token.
 
@@ -65,13 +67,13 @@ docker run -d --name ecobeetest --restart=always -v ./config:/config -it cdzomba
 ## Build
 
 ```shell
-go build -o ./ecobee_influx_connector .
+make build
 ```
 
 To cross-compile for eg. Linux/amd64:
 
 ```shell
-env GOOS=linux GOARCH=amd64 go build -o ./ecobee_influx_connector .
+env GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=$(./.version.sh)" -o ./ecobee_influx_connector .
 ```
 
 ## Install & Run via systemd on Linux
@@ -97,7 +99,7 @@ The connector does not directly support multiple thermostats. To support this us
 
 ## License
 
-Apache 2; see `LICENSE` in this repository.
+Apache 2.0; see `LICENSE` in this repository.
 
 ## Author
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,9 @@
+---
+version: "3.9"
+services:
+  ecobee_influx_connector:
+    image: cdzombak/ecobee_influx_connector:1
+    container_name: ecobee_influx_connector
+    restart: unless-stopped
+    volumes:
+      - /home/ME/.ecobee_influx_connector:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
----
-version: "3.9"
-services:
-  ecobee_influx_connector:
-    image: cdzombak/ecobee_influx_connector:latest
-    container_name: ecobee_influx_connector
-    restart: always
-    volumes:
-      - $DOCKERPATH/ecobee_influx_connector:/config

--- a/ecobee-influx-connector.example.service
+++ b/ecobee-influx-connector.example.service
@@ -5,9 +5,9 @@ After=network.target
 
 [Service]
 Type=simple
-User=cdzombak
-Group=cdzombak
-ExecStart=/usr/local/bin/ecobee_influx_connector -config "/home/cdzombak/.ecobee_influx_connector/config.json"
+User=ME
+Group=ME
+ExecStart=/usr/local/bin/ecobee_influx_connector -config "/home/ME/.ecobee_influx_connector/config.json"
 Restart=always
 RestartSec=5
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ import (
 	"ecobee_influx_connector/ecobee" // taken from https://github.com/rspier/go-ecobee and lightly customized
 )
 
+// Config describes the ecobee_influx_connector program's configuration.
+// It is used to parse the configuration JSON file.
 type Config struct {
 	APIKey                    string `json:"api_key"`
 	WorkDir                   string `json:"work_dir,omitempty"`
@@ -127,8 +129,8 @@ func main() {
 			log.Fatalf("InfluxDB did not pass health check: status %s; message '%s'", health.Status, *health.Message)
 		}
 	}
-	influxWriteApi := influxClient.WriteAPIBlocking(config.InfluxOrg, config.InfluxBucket)
-	_ = influxWriteApi
+	influxWriteAPI := influxClient.WriteAPIBlocking(config.InfluxOrg, config.InfluxBucket)
+	_ = influxWriteAPI
 
 	lastWrittenRuntimeInterval := 0
 	lastWrittenWeather := time.Time{}
@@ -169,7 +171,7 @@ func main() {
 						"voc":                 actualVOC,
 					}
 
-					err := influxWriteApi.WritePoint(ctx,
+					err := influxWriteAPI.WritePoint(ctx,
 						influxdb2.NewPoint(
 							"ecobee_air_quality",
 							map[string]string{thermostatNameTag: t.Name}, // tags
@@ -284,7 +286,7 @@ func main() {
 							if config.WriteCool2 {
 								fields["cool_2_run_time"] = cool2RunSec
 							}
-							err := influxWriteApi.WritePoint(ctx,
+							err := influxWriteAPI.WritePoint(ctx,
 								influxdb2.NewPoint(
 									"ecobee_runtime",
 									map[string]string{thermostatNameTag: t.Name},
@@ -347,7 +349,7 @@ func main() {
 							if presenceSupported {
 								fields["occupied"] = presence
 							}
-							err := influxWriteApi.WritePoint(ctx,
+							err := influxWriteAPI.WritePoint(ctx,
 								influxdb2.NewPoint(
 									"ecobee_sensor",
 									map[string]string{
@@ -399,7 +401,7 @@ func main() {
 						if config.AlwaysWriteWeather {
 							pointTime = time.Now()
 						}
-						err := influxWriteApi.WritePoint(ctx,
+						err := influxWriteAPI.WritePoint(ctx,
 							influxdb2.NewPoint(
 								ecobeeWeatherMeasurementName,
 								map[string]string{ // tags

--- a/main.go
+++ b/main.go
@@ -48,10 +48,18 @@ const (
 	ecobeeWeatherMeasurementName = "ecobee_weather"
 )
 
+var version = "<dev>"
+
 func main() {
-	var configFile = flag.String("config", "", "Configuration JSON file.")
-	var listThermostats = flag.Bool("list-thermostats", false, "List available thermostats, then exit.")
+	configFile := flag.String("config", "", "Configuration JSON file.")
+	listThermostats := flag.Bool("list-thermostats", false, "List available thermostats, then exit.")
+	printVersion := flag.Bool("version", false, "Print version and exit.")
 	flag.Parse()
+
+	if *printVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	if *configFile == "" {
 		fmt.Println("-config is required.")


### PR DESCRIPTION
Motivated by recent work with Docker and GitHub Actions on a personal project, plus this repo's insistence on trying to push PR branches to Docker, I've revamped how this repo is versioned, linted, built, and released:

- The program now has a version number, injected during the build process and viewable with the `-version` flag.
- A Makefile has been added to assist in local development and CI. It prints documentation if you run `make` with no targets or `make help`.
- The CI lint-and-build process runs on all pushes to `main`, `v*.*.*` tags, and PRs.
- PRs are now linted, and binaries, .debs, and Docker images are built. PR build products are not released anywhere.
- GitHub releases happen automatically when a `vX.Y.Z` tag is pushed. Binaries and .debs are attached.
  - Tags like `vX.Y.Z-alpha.A`, `-beta.B`, and `-rc.N` are also supported. These generate a GitHub prerelease.
  - Released (not prereleased) Debian packages are pushed to PackageCloud.
  - Lint failures block releases from happening.
- Docker images are pushed to Docker Hub and GHCR:
  - On every release: the tags `latest`, `X.Y.Z`, `X.Y`, and `X` are pushed
  - On pushes to `main`: the `main` tag is pushed
  - The README is updated in Docker Hub on every release
- All source in the repo now passes a battery of lint checks.
- The Dockerfile now uses a two stage build, resulting in a tiny final image. A variety of labels including metadata are added.
- Sample configuration files are renamed.
- Various other minor changes.